### PR TITLE
fix: TileJSON center value must be an array of 3 values.

### DIFF
--- a/src/service/mvt.rs
+++ b/src/service/mvt.rs
@@ -92,7 +92,7 @@ impl MvtService {
             "bounds": [-180.0,-90.0,180.0,90.0],
             "minzoom": 0,
             "maxzoom": 14,
-            "center": "0.0,0.0,2",
+            "center": [0.0, 0.0, 2],
             "basename": "{}"
         }}"#, tileset, tileset, tileset, tileset)).unwrap();
         let layers_metadata: Vec<(String,String)> = layers.iter().map(|layer| {


### PR DESCRIPTION
TileJSON spec says the centre must be an array of 3 values, not a string
with 3 values. This change is needed to make it work with Mapbox Studio
Classic