### PR TITLE
fix: Work with PostgreSQL columns which have a colon

### DIFF
--- a/src/datasource/postgis.rs
+++ b/src/datasource/postgis.rs
@@ -367,7 +367,8 @@ impl PostgisInput {
         } else {
             let mut cols: Vec<String> = self.detect_data_columns(layer, sql).iter().map(|&(ref name, ref casttype)| {
                 if casttype.is_empty() {
-                    name.clone()
+                    // Wrap in double quotes to guarantee validity. Columns might have colons
+                    format!("\"{}\"", name)
                 } else {
                     format!("{}::{}", &name, &casttype)
                 }


### PR DESCRIPTION
The default osm2pgsql imported data includes columns like
`addr:housenumber`. Without double quotes around that column name, the
SQL is invalid.