### PR TITLE
Don't regenerate existing tiles

### DIFF
--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -11,6 +11,7 @@ pub trait Cache {
     fn read<F>(&self, path: &str, read: F) -> bool
         where F : FnMut(&mut Read);
     fn write(&self, path: &str, obj: &[u8]) -> Result<(), io::Error>;
+    fn exists(&self, path: &str) -> bool;
 }
 
 
@@ -27,5 +28,9 @@ impl Cache for Nocache {
     fn write(&self, path: &str, obj: &[u8]) -> Result<(), io::Error>
     {
         Ok(())
+    }
+
+    fn exists(&self, path: &str) -> bool {
+        false
     }
 }

--- a/src/cache/filecache.rs
+++ b/src/cache/filecache.rs
@@ -33,6 +33,11 @@ impl Cache for Filecache {
         let mut f = try!(File::create(&fullpath));
         f.write_all(obj)
     }
+
+    fn exists(&self, path: &str) -> bool {
+        let fullpath = format!("{}/{}", self.basepath, path);
+        Path::new(&fullpath).exists()
+    }
 }
 
 #[test]

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -36,6 +36,13 @@ impl Cache for Tilecache {
             &Tilecache::Filecache(ref cache) => cache.write(path, obj),
         }
     }
+    fn exists(&self, path: &str) -> bool
+    {
+        match self {
+            &Tilecache::Nocache(ref cache)   => cache.exists(path),
+            &Tilecache::Filecache(ref cache) => cache.exists(path),
+        }
+    }
 }
 
 impl Config<Tilecache> for Tilecache {

--- a/src/service/mvt.rs
+++ b/src/service/mvt.rs
@@ -274,11 +274,16 @@ impl MvtService {
                         tileno += 1;
                         if skip { continue; }
 
-                        let mvt_tile = self.tile(&tileset.name, xtile, ytile, zoom);
-                        let mut tilegz = Vec::new();
-                        Tile::write_gz_to(&mut tilegz, &mvt_tile);
                         let path = format!("{}/{}/{}/{}.pbf", &tileset.name, zoom, xtile, ytile);
-                        let _ = self.cache.write(&path, &tilegz);
+
+                        if ! self.cache.exists(&path) {
+                            // Entry doesn't exist, so generate it
+                            let mvt_tile = self.tile(&tileset.name, xtile, ytile, zoom);
+                            let mut tilegz = Vec::new();
+                            Tile::write_gz_to(&mut tilegz, &mvt_tile);
+                            let _ = self.cache.write(&path, &tilegz);
+                        }
+
                         if progress { pb.inc(); }
                     }
                 }


### PR DESCRIPTION
When 'generate'ing all tiles, don't regenerate a tile if it already
exists. If you're generation gets interupted, you can restart it without
having to go start from the start.