### PR TITLE
Fix off by one error in --maxzoom arg to generate

### DIFF
--- a/src/service/mvt.rs
+++ b/src/service/mvt.rs
@@ -264,7 +264,7 @@ impl MvtService {
                 continue;
             }
             if progress { println!("Generating tileset '{}'...", tileset.name); }
-            for zoom in minzoom..maxzoom {
+            for zoom in minzoom..(maxzoom+1) {
                 let ref limit = limits[zoom as usize];
                 let mut pb = self.progress_bar(&format!("Level {}: ", zoom), &limit);
                 if progress { pb.tick(); }


### PR DESCRIPTION
If a user specifies `--minzoom 0 --maxzoom 4` for `t_rex generate`, they would expect it to generate tiles for zooms 0, 1, 2, 3, 4. However it currently only does 0, 1, 2, 3. This patch will fix this off-by-one-error