### PR TITLE
Allow for datasource url env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ port = 8080
 threads = 4
 ```
 
+The datasource url can be overridden by the environment variable `TREX_DATASOURCE_URL`, which takes precedence.
+
 ### Layer configuration
 
 Custom queries can be configured as PostGIS SQL queries.
@@ -258,7 +260,7 @@ Decode a vector tile:
 
 Unit tests which need a PostgreSQL connection are ignored by default.
 
-To run the database tests, declare the [connection](https://github.com/sfackler/rust-postgres#connecting) in an 
+To run the database tests, declare the [connection](https://github.com/sfackler/rust-postgres#connecting) in an
 environment variable `DBCONN`. Example:
 
     export DBCONN=postgresql://user:pass@localhost/natural_earth_vectors

--- a/src/datasource/postgis.rs
+++ b/src/datasource/postgis.rs
@@ -18,6 +18,7 @@ use core::layer::Layer;
 use core::Config;
 use toml;
 use std::collections::BTreeMap;
+use env;
 
 
 impl GeometryType {
@@ -666,15 +667,18 @@ impl DatasourceInput for PostgisInput {
 
 impl Config<PostgisInput> for PostgisInput {
     fn from_config(config: &toml::Value) -> Result<Self, String> {
-        config
-            .get("datasource")
-            .and_then(|d| d.get("url"))
-            .ok_or("Missing configuration entry 'datasource.url'".to_string())
-            .and_then(|val| {
-                          val.as_str()
-                              .ok_or("url entry is not a string".to_string())
-                      })
-            .and_then(|url| Ok(PostgisInput::new(url)))
+      match env::var("TREX_DATASOURCE_URL") {
+        Ok(url) => Ok(PostgisInput::new(url.as_str())),
+        Err(_) => config
+          .get("datasource")
+          .and_then(|d| d.get("url"))
+          .ok_or("Missing configuration entry 'datasource.url'".to_string())
+          .and_then(|val| {
+              val.as_str()
+              .ok_or("url entry is not a string".to_string())
+              })
+          .and_then(|url| Ok(PostgisInput::new(url)))
+      }
     }
 
     fn gen_config() -> String {


### PR DESCRIPTION
Add support for the environment variable TREX_DATASOURCE_URL to override
the datasource.url config field.